### PR TITLE
[agent:survivor-operator] Add click_targets_until_changed engine primitive

### DIFF
--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -143,3 +143,100 @@ def test_click_target_image_prefix_fails_fast_without_fallback(monkeypatch):
 
     with pytest.raises(ge_module.ImageClickError):
         engine.click_target('image:missing', retry=1)
+
+
+def test_click_targets_until_changed_returns_success_on_first_state_change(monkeypatch):
+    engine, _device = build_engine(
+        monkeypatch,
+        [{'text': 'start', 'x': 0.5, 'y': 0.5, 'confidence': 0.95}],
+    )
+
+    signatures = ['s1']
+
+    def fake_recent_signatures(count=None):
+        data = list(signatures)
+        if count is None:
+            return data
+        return data[-count:]
+
+    def fake_wait(_seconds=1):
+        signatures.append('s2')
+
+    engine.recent_signatures = fake_recent_signatures
+    engine.wait = fake_wait
+
+    result = engine.click_targets_until_changed(['start'])
+    assert result['success'] is True
+    assert result['clicked_target'] == 'start'
+    assert result['reason'] == 'state_changed'
+    assert result['attempts'] == 1
+
+
+def test_click_targets_until_changed_tries_next_target_after_no_change(monkeypatch):
+    engine, _device = build_engine(
+        monkeypatch,
+        [
+            {'text': 'alpha', 'x': 0.1, 'y': 0.2, 'confidence': 0.9},
+            {'text': 'beta', 'x': 0.8, 'y': 0.9, 'confidence': 0.95},
+        ],
+    )
+
+    signatures = ['s1']
+
+    def fake_recent_signatures(count=None):
+        data = list(signatures)
+        if count is None:
+            return data
+        return data[-count:]
+
+    wait_calls = {'n': 0}
+
+    def fake_wait(_seconds=1):
+        wait_calls['n'] += 1
+        if wait_calls['n'] == 1:
+            signatures.append('s1')
+        else:
+            signatures.append('s2')
+
+    engine.recent_signatures = fake_recent_signatures
+    engine.wait = fake_wait
+
+    result = engine.click_targets_until_changed(['alpha', 'beta'])
+    assert result['success'] is True
+    assert result['clicked_target'] == 'beta'
+    assert result['attempts'] == 2
+
+
+def test_click_targets_until_changed_returns_no_match(monkeypatch):
+    engine, _device = build_engine(monkeypatch, [])
+    result = engine.click_targets_until_changed(['missing'])
+
+    assert result['success'] is False
+    assert result['reason'] == 'no_match'
+    assert result['attempts'] == 0
+
+
+def test_click_targets_until_changed_returns_no_state_change(monkeypatch):
+    engine, _device = build_engine(
+        monkeypatch,
+        [{'text': 'start', 'x': 0.5, 'y': 0.5, 'confidence': 0.95}],
+    )
+
+    signatures = ['s1']
+
+    def fake_recent_signatures(count=None):
+        data = list(signatures)
+        if count is None:
+            return data
+        return data[-count:]
+
+    def fake_wait(_seconds=1):
+        signatures.append('s1')
+
+    engine.recent_signatures = fake_recent_signatures
+    engine.wait = fake_wait
+
+    result = engine.click_targets_until_changed(['start'])
+    assert result['success'] is False
+    assert result['reason'] == 'no_state_change'
+    assert result['attempts'] == 1


### PR DESCRIPTION
## Agent Name
survivor-operator

## Summary
Implements a new shared `GameEngine` primitive:
- `click_targets_until_changed(...)`

Behavior:
- Accepts prioritized targets.
- Clicks candidates sequentially.
- Verifies state change after each click via pre/post signature comparison.
- Stops on first state change and returns success + clicked target.
- Returns failure with reason/details when no match or no state change.

## Linked Issue
Closes #4

## API
Added to `GameEngine`:
- `click_targets_until_changed(targets, *, min_confidence=0.85, exact=False, verify_wait_s=0.8, max_candidates_per_target=1) -> dict`

Return contract:
- `success`, `clicked_target`, `attempts`, `changed`, `reason`, `details`
- Failure reasons: `no_match`, `no_state_change`

## Tests
Added coverage in `tests/test_game_engine.py` for:
- first target succeeds,
- later target succeeds after earlier no-change,
- all targets no-match,
- all targets no-state-change.

Local run:
- `uv run pytest tests/test_game_engine.py -q` (pass)

## Complexity / Risk
- **Complexity impact:** Medium (new reusable engine primitive + tests + event/metric plumbing)
- **Risk impact:** Low/Medium (runtime click path touched, bounded by isolated method and test coverage)

## Telemetry included
- Metrics counters added:
  - `sequential_click_attempts`
  - `sequential_click_success`
  - `sequential_click_failed`
- Structured events emitted:
  - `sequential_click_attempt`
  - `sequential_click_result`
