### PR TITLE
[agent:survivor-operator] Break skill_choice no-progress loop with localized streak breaker

### DIFF
--- a/tests/test_survivor_strategy.py
+++ b/tests/test_survivor_strategy.py
@@ -110,3 +110,20 @@ def test_never_click_buy_text_even_if_visible():
     strategy.step(engine, i=1)
 
     assert (0.5, 0.55) not in engine.clicked
+
+
+def test_skill_choice_streak_breaker_triggers_alternate_recovery():
+    engine = FakeEngine(
+        [
+            {'text': 'Choice', 'confidence': 0.96, 'x': 0.5, 'y': 0.1},
+            {'text': 'Unrelated Text', 'confidence': 0.9, 'x': 0.2, 'y': 0.3},
+        ]
+    )
+
+    strategy = SurvivorStrategy()
+
+    for i in range(1, 7):
+        strategy.step(engine, i=i)
+
+    assert (46.0 / 460, 960.0 / 1024) in engine.clicked
+    assert strategy.skill_choice_streak == 0


### PR DESCRIPTION
Agent Name: survivor-operator

Closes #6

## Summary
- Add a localized `skill_choice_streak` counter in `SurvivorStrategy`.
- Increment while continuously in skill-choice and reset on successful selection or scene exit.
- After 6 consecutive no-exit skill-choice passes, trigger existing alternate recovery sequence via `_force_alternate_recovery(...)` and emit explicit decision reason `skill_choice_streak_breaker`.

## Why this fixes the incident
Observed live pattern: repeated `refresh` + `text_click_miss(refresh)` + fallback card taps with near-zero template/text success, but no hard-stuck detection. This change adds a deterministic circuit-breaker for that exact pattern.

## Complexity/tradeoffs
- Localized to `survivor.py` (no engine changes).
- Uses existing safe recovery path to avoid adding new navigation primitives.
- Threshold (6) is conservative; may trigger occasional early recovery under extreme OCR noise, but avoids unbounded loops.

## Validation
- `uv run pytest -q tests/test_survivor_strategy.py` => 3 passed.
- New unit test: `test_skill_choice_streak_breaker_triggers_alternate_recovery`.
- Decision logging now surfaces `reason=skill_choice_streak_breaker` for observability.
