### PR TITLE
[agent:game-architect] Establish engine progress signal path for no-progress detection

### DIFF
--- a/docs/ENGINE_PROGRESS_SIGNAL_PLAN.md
+++ b/docs/ENGINE_PROGRESS_SIGNAL_PLAN.md
@@ -1,0 +1,39 @@
+# Engine Progress Signal Plan (Issue #8)
+
+## Summary
+Introduce a stable, low-noise engine progress token API for no-progress detection that is robust to OCR churn and UI refresh loops.
+
+## Proposed API (initial)
+- `compute_progress_token(frame_bundle, window_cfg) -> ProgressSignal`
+- `ProgressSignal`:
+  - `token: str` (stable hash over structural anchors)
+  - `changed: bool` (vs previous debounced token)
+  - `confidence: float` (0..1)
+  - `diagnostics: { anchors_used, ocr_regions_used, debounce_window_ms }`
+
+## Architecture Rationale
+- Moves progress semantics from strategy-local heuristics into core engine.
+- Promotes composability and consistent observability across scenes/games.
+- Allows strategies to consume one stable signal instead of bespoke loop-breakers.
+
+## Complexity / Risk
+- Complexity: Medium-High (cross-cutting signal pipeline + calibration)
+- Risks:
+  - false progress (over-sensitive anchors)
+  - missed progress (over-debounced token)
+  - game-specific UI variance
+- Mitigations:
+  - conservative defaults
+  - per-scene diagnostics
+  - phased rollout (opt-in)
+
+## Rollback Plan
+- Feature-flag all strategy consumption (`engine_progress_signal_enabled=false` by default in initial merge).
+- Keep existing no-progress fallback path active.
+- Disable flag to revert behavior without code rollback.
+
+## Test Plan
+- Unit: token stability under OCR text churn / minor redraw noise.
+- Unit: token change under meaningful scene transitions.
+- Integration: known `skill_choice` loop and escalation behavior with/without signal.
+- Metrics: emit token-change rate, confidence histogram, no-progress escalation triggers.


### PR DESCRIPTION
## Issue linkage
Refs #8

## Why
Issue #8 is approved and requires an active engine-change PR path. This PR establishes that path with architecture/test/rollback scaffolding before full implementation.

## Agent policy compliance
- Worktree: ../wt-game-architect-progress-signal
- Branch: agent/game-architect/progress-signal
- No direct commits to master/main

## Architecture rationale
- Progress semantics should live in engine, not strategy-local OCR churn heuristics.
- A stable token abstraction improves reuse, reliability, and telemetry consistency across scenes/games.

## Complexity / risk
- Complexity: Medium-High (cross-cutting signal extraction + debounce calibration).
- Risks: false positive/negative progress detection due to sensitivity tuning.
- Mitigation: conservative defaults, diagnostics, phased opt-in rollout.

## Rollback
- Gate strategy consumption with feature flag.
- Keep existing no-progress fallback path.
- Disable flag to revert behavior immediately.

## Included in this PR
- docs/ENGINE_PROGRESS_SIGNAL_PLAN.md scaffold defining API direction, testing obligations, and metrics.

## Next implementation steps
1. Add ProgressSignal data model + token computation pipeline in engine.
2. Add unit/integration tests from plan.
3. Wire optional strategy consumption behind feature flag.
4. Expand telemetry and verify loop scenarios.
