### PR TITLE
[agent:game-architect] Stage-1 engine/script boundary contract for #11

### DIFF
--- a/docs/architecture/issue-11-engine-script-boundary.md
+++ b/docs/architecture/issue-11-engine-script-boundary.md
@@ -1,0 +1,60 @@
+# Issue #11: Engine ↔ Script Boundary Contract (Stage Plan)
+
+## Decision trail
+
+- **Problem statement:** Engine internals and game scripts are coupled through private fields and ad-hoc call patterns.
+- **Proposed approach:** Introduce a minimal runtime contract (`EngineRuntime`) and migrate scripts to consume only that contract.
+- **Simpler alternative considered:** Keep current structure and only document conventions (rejected: no enforcement, coupling remains hidden).
+- **Complexity impact:** Medium
+- **Risk impact:** Medium
+- **Decision:** APPROVE (staged, contract-first)
+
+## Contract ownership map
+
+- **Engine core owns**
+  - Device I/O and screenshot lifecycle
+  - OCR + template integration
+  - Runtime state signatures / stuck detection
+  - Click/refresh/wait sequencing semantics
+- **Game scripts own**
+  - Scene interpretation and game policy
+  - Action selection and fallback heuristics
+  - Game-specific risk filters
+
+## Stage plan
+
+### Stage 1 (this PR): boundary contract + first migration slice
+
+- Add `game_driver.contracts.EngineRuntime` protocol as explicit engine->script API surface.
+- Expose `GameEngine.text_locations` as stable read-only boundary field.
+- Migrate `SurvivorStrategy` to use boundary field rather than `engine._locations`.
+- Add contract tests and migration notes.
+
+Acceptance checkpoint:
+- `GameEngine` satisfies `EngineRuntime` at runtime.
+- `SurvivorStrategy` no longer reaches into `engine._locations`.
+
+Rollback:
+- Revert protocol + property + strategy call-site updates in one commit.
+
+### Stage 2: dependency-direction cleanup
+
+- Move strategy-facing abstractions into a dedicated `runtime/` (or `contracts/`) module.
+- Add forbidden dependency checks (scripts cannot import device/analyzer internals).
+- Introduce adapter shims only where needed.
+
+### Stage 3: mechanical module separation
+
+- Relayout files into explicit `core/` and `games/` boundaries.
+- Keep behavior unchanged, measured with existing tests + telemetry logs.
+
+### Stage 4: shim removal and policy hardening
+
+- Remove temporary adapters.
+- Finalize docs and enforce contract in CI/tests.
+
+## Non-goals (Stage 1)
+
+- No runtime-loop behavior changes.
+- No broad file moves yet.
+- No new game features.

--- a/src/game_driver/contracts.py
+++ b/src/game_driver/contracts.py
@@ -1,0 +1,70 @@
+"""Boundary contracts between core engine runtime and game scripts.
+
+Stage-1 goal: codify the minimum surface area that a game strategy may depend on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+
+TextLocation = dict[str, object]
+
+
+@runtime_checkable
+class EngineRuntime(Protocol):
+    """Minimal contract consumed by game scripts.
+
+    This intentionally excludes direct device/analyzer/template internals.
+    """
+
+    @property
+    def text_locations(self) -> Sequence[TextLocation]: ...
+
+    def contains(self, text, exact: bool = False, min_confidence: float = 0.0) -> bool: ...
+
+    def get_matched_locations(
+        self,
+        text,
+        exact: bool = False,
+        min_confidence: float = 0.0,
+    ) -> list[TextLocation]: ...
+
+    def click_text(
+        self,
+        text,
+        retry: int = 5,
+        exact: bool = False,
+        min_confidence: float = 0.0,
+    ) -> bool: ...
+
+    def try_click_text(
+        self,
+        text,
+        exact: bool = False,
+        min_confidence: float = 0.0,
+    ) -> bool: ...
+
+    def click_first_text(
+        self,
+        text_list,
+        exact: bool = False,
+        min_confidence: float = 0.0,
+    ) -> tuple[bool, str | None]: ...
+
+    def try_click_template(self, name_or_path, threshold: float = 0.88, **kwargs) -> bool: ...
+
+    def click(self, x, y, wait: bool = True) -> None: ...
+
+    def wait(self, seconds: float = 1) -> None: ...
+
+    def debug(self): ...
+
+    def recent_signatures(self, count: int | None = None) -> list[str]: ...
+
+    def is_stuck(self, repeat_threshold: int = 8) -> bool: ...
+
+    def is_cycle_stuck(self, cycle_len: int = 2, min_cycles: int = 3) -> bool: ...
+
+    def metrics(self) -> dict[str, object]: ...

--- a/src/game_driver/game_engine.py
+++ b/src/game_driver/game_engine.py
@@ -88,6 +88,12 @@ class GameEngine:
         texts.sort()
         return '|'.join(texts[:12])
 
+    @property
+    def text_locations(self):
+        # Stage-1 boundary contract: scripts consume this stable read-only view
+        # instead of reaching into private engine fields.
+        return list(self._locations)
+
     def refresh(self):
         self._screenshot = self.device.screenshot()
         self._locations = self.analyzer.extract_text_locations(self._screenshot)

--- a/src/game_driver/games/survivor.py
+++ b/src/game_driver/games/survivor.py
@@ -3,6 +3,8 @@ import re
 from datetime import datetime
 from pathlib import Path
 
+from game_driver.contracts import EngineRuntime
+
 logger = logging.getLogger(__name__)
 
 
@@ -140,8 +142,8 @@ class SurvivorStrategy:
         self.skill_choice_streak = 0
 
     @staticmethod
-    def _text_samples(engine):
-        return [item['text'].lower() for item in engine._locations]
+    def _text_samples(engine: EngineRuntime):
+        return [str(item['text']).lower() for item in engine.text_locations]
 
     @staticmethod
     def _is_numeric_noise(text):
@@ -157,8 +159,8 @@ class SurvivorStrategy:
             detail,
         )
 
-    def _contains_high_risk_buy(self, engine):
-        for item in engine._locations:
+    def _contains_high_risk_buy(self, engine: EngineRuntime):
+        for item in engine.text_locations:
             if item.get('confidence', 0) < 0.93:
                 continue
             text = str(item.get('text', '')).lower()
@@ -301,8 +303,8 @@ class SurvivorStrategy:
             exact=False,
         )
 
-    def _try_click_skill_alias(self, engine, min_confidence=0.88):
-        for item in engine._locations:
+    def _try_click_skill_alias(self, engine: EngineRuntime, min_confidence=0.88):
+        for item in engine.text_locations:
             if item.get('confidence', 0) < min_confidence:
                 continue
             text = str(item.get('text', '')).lower()

--- a/tests/test_engine_script_contract.py
+++ b/tests/test_engine_script_contract.py
@@ -1,0 +1,64 @@
+from game_driver import game_engine as ge_module
+from game_driver.contracts import EngineRuntime
+from game_driver.games.survivor import SurvivorStrategy
+
+
+class FakeDevice:
+    def __init__(self):
+        self.clicks = []
+
+    def screenshot(self):
+        return object()
+
+    def click(self, x, y):
+        self.clicks.append((x, y))
+
+
+class FakeAnalyzer:
+    def __init__(self, locations):
+        self.locations = locations
+
+    def extract_text_locations(self, _image):
+        return list(self.locations)
+
+
+def build_engine(monkeypatch, locations):
+    fake_device = FakeDevice()
+    fake_analyzer = FakeAnalyzer(locations)
+
+    monkeypatch.setattr(ge_module, 'Device', lambda: fake_device)
+    monkeypatch.setattr(ge_module, 'create_analyzer', lambda: fake_analyzer)
+
+    engine = ge_module.GameEngine()
+    return engine, fake_device
+
+
+def test_game_engine_satisfies_engine_runtime_contract(monkeypatch):
+    engine, _ = build_engine(monkeypatch, [])
+    assert isinstance(engine, EngineRuntime)
+
+
+def test_survivor_strategy_reads_text_locations_boundary(monkeypatch):
+    engine, _ = build_engine(
+        monkeypatch,
+        [
+            {'text': 'Mission', 'x': 0.5, 'y': 0.5, 'confidence': 0.9},
+            {'text': 'Start', 'x': 0.6, 'y': 0.6, 'confidence': 0.92},
+        ],
+    )
+
+    samples = SurvivorStrategy._text_samples(engine)
+    assert samples == ['mission', 'start']
+
+
+def test_text_locations_isolation_from_external_mutation(monkeypatch):
+    engine, _ = build_engine(
+        monkeypatch,
+        [{'text': 'safe', 'x': 0.1, 'y': 0.2, 'confidence': 0.9}],
+    )
+
+    external = engine.text_locations
+    external.clear()
+
+    # engine internals should remain unchanged
+    assert engine.contains('safe') is True

--- a/tests/test_survivor_strategy.py
+++ b/tests/test_survivor_strategy.py
@@ -7,6 +7,10 @@ class FakeEngine:
         self.clicked = []
         self._signatures = ['fake-signature']
 
+    @property
+    def text_locations(self):
+        return list(self._locations)
+
     def is_stuck(self, repeat_threshold=8):
         return False
 


### PR DESCRIPTION
## Summary

Implements Issue #11 Stage-1 (contract-first) boundary definition between engine core and game scripts.

### What changed

- Added explicit boundary protocol: `game_driver.contracts.EngineRuntime`.
- Added `GameEngine.text_locations` read-only boundary property.
- Migrated `SurvivorStrategy` off `engine._locations` to boundary-facing `engine.text_locations`.
- Added architecture decision + staged migration plan doc:
  - `docs/architecture/issue-11-engine-script-boundary.md`
- Added boundary tests:
  - `tests/test_engine_script_contract.py`
- Updated strategy fake engine test double to expose `text_locations`.

## Agent

- Agent Name: `game-architect`

## Linked issue

Refs #11

## Architecture / tradeoffs

- Complexity impact: **medium**
  - Adds one new interface layer (Protocol), but reduces hidden coupling to private fields.
- Risk impact: **medium-low**
  - No engine-loop behavior changes; migration is contract-surface only.
- Tradeoff accepted:
  - Stage-1 keeps broad method surface in protocol for compatibility, then narrows in later stages.

## Determinism / reliability

- Core click/wait/refresh semantics are unchanged.
- Existing test suite remains green; new contract tests added.

## Rollback plan

- Revert this commit to remove protocol/property and restore previous strategy access.
- No data/state migration required.

## Validation

- `uv run pytest -q` → passed (26 tests)
