### PR TITLE
[agent:game-architect] Enforce worktree path convention and cleanup ownership

### DIFF
--- a/docs/agents/AGENT_WORKFLOW.md
+++ b/docs/agents/AGENT_WORKFLOW.md
@@ -10,8 +10,11 @@ This repo uses a strict multi-agent workflow.
 Suggested branch naming:
 - `agent/<agent-name>/<short-task>`
 
-Suggested worktree path:
-- `../wt-<agent-name>-<short-task>`
+Required worktree path:
+- `worktrees/<agent_name>/<feature_name>`
+
+Cleanup ownership:
+- The agent (or person) who created a worktree is responsible for cleaning it up after the PR is merged/closed.
 
 ## 2) No direct commits to master/main
 - Direct commits on `master`/`main` are prohibited.


### PR DESCRIPTION
## Summary
Updates workflow policy to enforce the new worktree convention and explicit cleanup ownership.

## What changed
- Changed worktree path guidance from suggested legacy style to required pattern:
  - `worktrees/<agent_name>/<feature_name>`
- Added explicit cleanup ownership rule:
  - the creator of a worktree is responsible for cleaning it up after PR merge/close.

## Agent
- Agent Name: `game-architect`

## Linked issue
Closes #23

## Architecture / tradeoffs
- Complexity impact: **low** (policy text only)
- Risk impact: **low** (no runtime/code behavior changes)

## Rollback plan
Revert this doc-only commit.
