### PR TITLE
[agent:survivor-operator] fix skill_choice false-negative gating to stop refresh loop

### DIFF
--- a/src/game_driver/games/survivor.py
+++ b/src/game_driver/games/survivor.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class SurvivorStrategy:
-    STRATEGY_REVISION = 'pr20-skill-choice-hotfix-20260219-1731'
+    STRATEGY_REVISION = 'pr25-skill-choice-scene-fallback-20260219-2016'
 
     def __init__(self, artifact_dir='artifacts/stuck'):
         self.artifact_dir = Path(artifact_dir)
@@ -157,6 +157,13 @@ class SurvivorStrategy:
     def _text_samples(engine: EngineRuntime):
         return [str(item['text']).lower() for item in engine.text_locations]
 
+    def _is_skill_choice_scene(self, engine: EngineRuntime):
+        if engine.contains('choice', min_confidence=0.9):
+            return True
+        # Fallback for low-confidence OCR where `choice` text exists but
+        # strict confidence gating fails.
+        return any('choice' in text for text in self._text_samples(engine))
+
     @staticmethod
     def _is_numeric_noise(text):
         return bool(re.fullmatch(r'[0-9:.xbmkn+\- ]{2,}', text.lower()))
@@ -201,7 +208,7 @@ class SurvivorStrategy:
 
     def _contains_low_energy_text(self, engine):
         # Skill choice includes terms like "Energy Drink"; avoid false low-energy mode.
-        if engine.contains('choice', min_confidence=0.9):
+        if self._is_skill_choice_scene(engine):
             return False
 
         return any(
@@ -492,7 +499,7 @@ class SurvivorStrategy:
         return (numeric_noise >= 8 and has_timer) or (numeric_noise >= 6 and has_level)
 
     def _scene_kind(self, engine):
-        if engine.contains('choice', min_confidence=0.9):
+        if self._is_skill_choice_scene(engine):
             return 'skill_choice'
         if self._is_in_battle(engine):
             return 'battle'
@@ -648,7 +655,7 @@ class SurvivorStrategy:
 
         # Prioritize skill-choice handling before generic controls to avoid
         # false matches (e.g. "start" matching "starforge").
-        if engine.contains('choice', min_confidence=0.9):
+        if current_scene == 'skill_choice':
             self.skill_choice_streak += 1
 
             # Hard fail-safe: treat persistent choice as non-progress risk and


### PR DESCRIPTION
## Summary
This PR fixes a specific live recurrence where survivor stayed in `skill_choice` but still ran refresh/text-miss behavior due to strict confidence gating on `choice`.

## Root cause
`step()` and `_scene_kind()` gated skill-choice handling on:
- `engine.contains('choice', min_confidence=0.9)`

In live OCR, `choice` text can be present but below that confidence. When that happened, strategy fell through to non-skill generic paths and emitted repeated refresh/no-progress actions.

## Changes
- Added `_is_skill_choice_scene()` with fallback detection:
  - primary: strict `engine.contains('choice', min_confidence=0.9)`
  - fallback: OCR text sample contains substring `choice`
- Switched skill-choice branch gating in `step()` to `current_scene == 'skill_choice'`.
- Reused fallback detector in `_scene_kind()` and `_contains_low_energy_text()`.
- Added test: `test_skill_choice_low_confidence_text_fallback_blocks_refresh_loop`.
- Updated strategy revision tag for telemetry traceability.

## Validation
### Test
- `PYTHONPATH=src ... pytest -q tests/test_survivor_strategy.py::test_skill_choice_low_confidence_text_fallback_blocks_refresh_loop tests/test_survivor_strategy.py::test_skill_choice_disables_refresh_click_path`
- Result: `2 passed`

### Live run signal (not unit-test-only)
- New short live run generated `artifacts/events.jsonl` in this worktree.
- In latest `scene_hint=skill_choice` window (134 rows):
  - `text_click_miss target=refresh`: **0**
- Historical stuck window (`/Users/chunzhang/game_driver/artifacts/events.jsonl`, 11:37 block):
  - `text_click_miss target=refresh`: **2** within 11 skill-choice rows

So the exact loop signature (`skill_choice` + refresh-miss recurrence) is removed in the new run.

## Agent metadata
- Agent Name: survivor-operator
- Issue: Refs #25
