### PR TITLE
Follow-up: direct card-pick first in skill_choice

### DIFF
--- a/src/game_driver/games/survivor.py
+++ b/src/game_driver/games/survivor.py
@@ -651,55 +651,10 @@ class SurvivorStrategy:
         if engine.contains('choice', min_confidence=0.9):
             self.skill_choice_streak += 1
 
-            # Hard fail-safe: treat persistent choice as non-progress risk and
-            # immediately force alternate recovery instead of OCR-heavy loops.
-            self._emit_decision(
-                i,
-                'skill_choice',
-                'fallback',
-                'skill_choice_immediate_recovery',
-                detail=f'streak={self.skill_choice_streak}',
-            )
-            self._force_alternate_recovery(engine, i, 'skill_choice_immediate_recovery')
-            self.skill_choice_streak = 0
-            return
-
-            clicked, skill = self._try_click_skill_targets(
-                engine,
-                self.preferred_skills,
-                min_confidence=0.88,
-            )
-            if clicked:
-                self._emit_decision(i, skill, 'clicked', 'skill_preferred_or_alias')
-                self.skill_choice_streak = 0
-                return
-
-            hotspot_closed, hotspot = self._try_click_skill_choice_hotspots(engine)
-            if hotspot_closed:
-                self._emit_decision(
-                    i,
-                    hotspot,
-                    'clicked',
-                    'skill_choice_hotspot_close',
-                )
-                self.skill_choice_streak = 0
-                return
-
-            # Disable refresh in skill_choice: OCR misses on refresh are a
-            # dominant no-progress loop source in production telemetry.
-            self._emit_decision(i, 'refresh', 'skip', 'skill_refresh_disabled')
-
-            clicked, skill = self._try_click_skill_targets(
-                engine,
-                self.secondary_skills,
-                min_confidence=0.88,
-            )
-            if clicked:
-                self._emit_decision(i, skill, 'clicked', 'skill_secondary_or_alias')
-                self.skill_choice_streak = 0
-                return
-
-            self._emit_decision(i, 'skill_choice', 'fallback', 'card_force_select')
+            # Minimal deterministic path for skill-choice UI:
+            # choose a card directly (no OCR text-click path), then tap the
+            # lower card body to confirm/select.
+            self._emit_decision(i, 'skill_choice', 'fallback', 'card_force_select_direct')
             fallback_cards = [
                 (0.17, 0.44),
                 (0.50, 0.44),
@@ -707,20 +662,19 @@ class SurvivorStrategy:
             ]
             x, y = fallback_cards[i % len(fallback_cards)]
             engine.click(x, y, wait=False)
-            engine.wait(0.6)
+            engine.wait(0.5)
             if not engine.contains('choice', min_confidence=0.88):
                 self.skill_choice_streak = 0
                 return
 
             engine.click(x, 0.54, wait=False)
-            engine.wait(0.6)
+            engine.wait(0.5)
             if not engine.contains('choice', min_confidence=0.88):
                 self.skill_choice_streak = 0
                 return
 
-            # Circuit-break persistent skill-choice loops where refresh/text matching
-            # repeatedly fails and fallback taps never transition state.
-            if self.skill_choice_streak >= 6:
+            # If choice still persists for a few loops, escalate to alternate recovery.
+            if self.skill_choice_streak >= 3:
                 self._emit_decision(
                     i,
                     'skill_choice',

--- a/tests/test_survivor_strategy.py
+++ b/tests/test_survivor_strategy.py
@@ -142,7 +142,7 @@ def test_skill_choice_streak_breaker_triggers_alternate_recovery():
     assert strategy.skill_choice_streak == 0
 
 
-def test_skill_choice_fast_breaker_triggers_by_second_iteration():
+def test_skill_choice_fast_breaker_triggers_by_third_iteration():
     engine = FakeEngine(
         [
             {'text': 'Choice', 'confidence': 0.96, 'x': 0.5, 'y': 0.1},
@@ -153,12 +153,13 @@ def test_skill_choice_fast_breaker_triggers_by_second_iteration():
     strategy = SurvivorStrategy()
     strategy.step(engine, i=1)
     strategy.step(engine, i=2)
+    strategy.step(engine, i=3)
 
     assert (46.0 / 460, 960.0 / 1024) in engine.clicked
     assert strategy.skill_choice_streak == 0
 
 
-def test_skill_choice_immediately_uses_alternate_recovery_path():
+def test_skill_choice_uses_direct_card_force_select_path():
     engine = FakeEngine(
         [
             {'text': 'Choice', 'confidence': 0.96, 'x': 0.5, 'y': 0.1},
@@ -170,7 +171,7 @@ def test_skill_choice_immediately_uses_alternate_recovery_path():
     strategy.step(engine, i=1)
 
     assert engine.clicked
-    assert engine.clicked[0] == (46.0 / 460, 960.0 / 1024)
+    assert engine.clicked[0] in [(0.17, 0.44), (0.50, 0.44), (0.81, 0.44)]
 
 
 def test_skill_choice_disables_refresh_click_path():
@@ -198,7 +199,7 @@ def test_skill_choice_disables_refresh_click_path():
     assert engine.refresh_clicks == 0
 
 
-def test_skill_choice_avoids_hotspot_path_when_immediate_recovery_enabled():
+def test_skill_choice_avoids_hotspot_path_when_direct_card_select_enabled():
     engine = FakeEngine(
         [
             {'text': 'Choice', 'confidence': 0.96, 'x': 0.5, 'y': 0.1},
@@ -211,15 +212,11 @@ def test_skill_choice_avoids_hotspot_path_when_immediate_recovery_enabled():
 
     assert engine.clicked
     assert (0.94, 0.07) not in engine.clicked
-    assert engine.clicked[0] == (46.0 / 460, 960.0 / 1024)
+    assert engine.clicked[0] in [(0.17, 0.44), (0.50, 0.44), (0.81, 0.44)]
 
 
-def test_skill_choice_low_text_success_breaker_triggers_immediately():
-    class LowSuccessEngine(FakeEngine):
-        def metrics(self):
-            return {'text_click_success_rate': 0.009}
-
-    engine = LowSuccessEngine(
+def test_skill_choice_streak_breaker_triggers_after_direct_card_retries():
+    engine = FakeEngine(
         [
             {'text': 'Choice', 'confidence': 0.96, 'x': 0.5, 'y': 0.1},
             {'text': 'Noise', 'confidence': 0.90, 'x': 0.2, 'y': 0.3},
@@ -228,6 +225,8 @@ def test_skill_choice_low_text_success_breaker_triggers_immediately():
 
     strategy = SurvivorStrategy()
     strategy.step(engine, i=1)
+    strategy.step(engine, i=2)
+    strategy.step(engine, i=3)
 
     assert (46.0 / 460, 960.0 / 1024) in engine.clicked
     assert strategy.skill_choice_streak == 0


### PR DESCRIPTION
## Summary
- switch `skill_choice` handling to a deterministic direct card-pick path (`card_force_select_direct`)
- remove OCR-heavy text actions from this scene path (no refresh/text-click loop)
- keep a short streak breaker (`>=3`) to alternate recovery if card picks still do not transition scene

## Why this follow-up
Latest stuck screenshot OCR indicates a genuine "Select a skill" UI. Immediate back/recovery can stall because progression requires selecting a card. This patch biases to direct skill selection first, then recover only on repeated persistence.

## Validation
- `.venv/bin/python -m pytest -q tests/test_survivor_strategy.py tests/test_game_engine.py`
- `20 passed`
