### PR TITLE
[agent:survivor-operator] feat(survivor): hard no-progress breaker + progress-first metrics (fixes #32)

### DIFF
--- a/scripts/survivor.py
+++ b/scripts/survivor.py
@@ -117,6 +117,11 @@ def _make_engine_listener(state):
             success = False
             reason = 'no_match'
 
+        strategy_metrics = {}
+        strategy = state.get('strategy')
+        if strategy is not None and hasattr(strategy, 'progress_metrics'):
+            strategy_metrics = strategy.progress_metrics()
+
         event_row = {
             'ts': datetime.now().isoformat(),
             'event': event,
@@ -130,6 +135,12 @@ def _make_engine_listener(state):
             'success': success,
             'reason': reason,
             'metrics_snapshot': state['engine'].metrics(),
+            'objective_delta_per_min': strategy_metrics.get('objective_delta_per_min', 0.0),
+            'scene_transition_rate': strategy_metrics.get('scene_transition_rate', 0.0),
+            'no_progress_duration': strategy_metrics.get('no_progress_duration', 0.0),
+            'action_to_progress_ratio': strategy_metrics.get('action_to_progress_ratio', 0.0),
+            'tier_jump_attempts': strategy_metrics.get('tier_jump_attempts', 0),
+            'tier_jump_cooldown_remaining': strategy_metrics.get('tier_jump_cooldown_remaining', 0.0),
         }
         _jsonl_append(EVENTS_PATH, event_row)
 
@@ -158,7 +169,7 @@ def main():
     while True:
         engine = GameEngine()
         strategy = SurvivorStrategy()
-        state = {'iter': -1, 'engine': engine, 'consecutive_errors': 0}
+        state = {'iter': -1, 'engine': engine, 'strategy': strategy, 'consecutive_errors': 0}
 
         engine.add_listener(_make_engine_listener(state))
 


### PR DESCRIPTION
## Summary
Implements a minimal safe slice for #32:
- hard no-progress breaker with objective/scene delta thresholding
- tier-jump recovery trigger
- bounded retries + cooldown to avoid thrash
- progress-first metrics emission fields for dashboard

## What changed
- `SurvivorStrategy` now tracks:
  - no-progress duration (`no_progress_started_at` + monotonic clock)
  - objective-delta events (signature changes)
  - scene-transition events
  - bounded tier-jump attempts/cooldown
- Hard breaker triggers only when **both** thresholds are met:
  - `no_progress_steps >= hard_no_progress_steps`
  - `no_progress_duration >= hard_no_progress_seconds`
- Added `progress_metrics()` with:
  - `objective_delta_per_min` (placeholder based on signature delta)
  - `scene_transition_rate`
  - `no_progress_duration`
  - `action_to_progress_ratio`
- Event stream (`scripts/survivor.py`) now emits above metrics per event row.

## Tests
- `uv run pytest -q` → **34 passed**
- New tests in `tests/test_survivor_strategy.py`:
  - `test_hard_no_progress_breaker_triggers_with_duration_and_step_threshold`
  - `test_progress_metrics_fields_emitted_with_placeholders`

## Runtime log evidence
Generated dry runtime log (no device required): `artifacts/pr32_runtime.log`
Contains breaker + metrics evidence, e.g.
- `reason=hard_no_progress_tier_jump ... duration=1.2s attempt=1/2`
- `progress_metrics {'objective_delta_per_min': 0.0, 'scene_transition_rate': 0.0, 'no_progress_duration': ..., 'action_to_progress_ratio': ...}`

## Rebase status
- Rebased cleanly on `origin/master` before push.
