### PR TITLE
[agent:game-architect] Centralize close-control handling primitive (fixes #42)

### DIFF
--- a/src/game_driver/contracts.py
+++ b/src/game_driver/contracts.py
@@ -77,6 +77,16 @@ class EngineRuntime(Protocol):
         """Attempt a single-pass template/image click and return success."""
         ...
 
+    def try_click_close_control(
+        self,
+        *,
+        min_confidence: float = 0.9,
+        template_candidates=None,
+        allow_safe_tap: bool = False,
+    ) -> tuple[bool, str | None]:
+        """Try standard close/dismiss controls (text, glyph, templates, safe-tap)."""
+        ...
+
     def click(self, x, y, wait: bool = True) -> None:
         """Execute a coordinate click.
 

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -240,3 +240,32 @@ def test_click_targets_until_changed_returns_no_state_change(monkeypatch):
     assert result['success'] is False
     assert result['reason'] == 'no_state_change'
     assert result['attempts'] == 1
+
+
+def test_try_click_close_control_prefers_textual_close(monkeypatch):
+    engine, device = build_engine(
+        monkeypatch,
+        [
+            {'text': 'Close', 'x': 0.88, 'y': 0.08, 'confidence': 0.95},
+            {'text': 'Other', 'x': 0.5, 'y': 0.5, 'confidence': 0.95},
+        ],
+    )
+
+    ok, reason = engine.try_click_close_control()
+
+    assert ok is True
+    assert reason == 'close'
+    assert device.clicks[0] == (0.88, 0.08)
+
+
+def test_try_click_close_control_uses_safe_tap_when_enabled(monkeypatch):
+    engine, device = build_engine(
+        monkeypatch,
+        [{'text': 'Noise', 'x': 0.5, 'y': 0.5, 'confidence': 0.95}],
+    )
+
+    ok, reason = engine.try_click_close_control(allow_safe_tap=True)
+
+    assert ok is True
+    assert reason == 'close_safe_tap'
+    assert device.clicks[:2] == [(0.92, 0.08), (0.5, 0.1)]


### PR DESCRIPTION
## Summary
- add GameEngine.try_click_close_control as shared close/dismiss primitive
- migrate SurvivorStrategy close-control path to engine primitive
- add engine tests for text-close and safe-tap behavior

## Issue
- fixes #42
- architecture linkage: #34

## Agent metadata
- agent: game-architect
- session: game-architect
- workflow: issue-first