### PR TITLE
[agent:pr-governor] enforce #55 governance rubric in PR flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+## Summary
+- What changed?
+- Why now?
+
+## Linked issue
+- Refs #<id> (or Closes #<id>)
+
+## Agent
+- agent: <name>
+
+## Governance Rubric (required)
+### Simplicity Delta
+- Score: `+1 | 0 | -1`
+- What got simpler?
+- If complexity was added, why unavoidable and how contained?
+
+### Composability Gain
+- Reusable primitive/boundary improved:
+- Duplication reduced:
+- Downstream slice/use-case unlocked:
+
+### Traceability Coverage
+For decision/action paths touched by this PR, confirm coverage:
+- `reason` (typed stable enum):
+- `correlation_id` (attempt/request lineage):
+- `event` (typed event/category):
+
+If partial, list gap + follow-up issue:
+- Gap:
+- Follow-up issue: #
+
+## Validation
+- [ ] Tests added/updated
+- [ ] Relevant tests pass locally
+- [ ] Rollback/failure mode considered
+
+## Risk & blast radius
+- Expected impact (low/med/high):
+- User-visible risk:
+- Operational/debugging risk:
+
+## PR Governor policy note
+Rubric omissions are warned for merge-velocity.
+Blocking is reserved for substantive risk (correctness/operability/architecture):
+- missing/incorrect traceability on touched decision paths
+- unjustified high-blast-radius complexity increase
+- composability regression causing duplicate stacks
+- failure diagnosability regression

--- a/docs/agents/PR_GOVERNOR.md
+++ b/docs/agents/PR_GOVERNOR.md
@@ -27,22 +27,43 @@ Enforce `AGENT_WORKFLOW.md` strictly:
 - **Worktree + branch flow** must be used.
 - **No direct commits to `master`/`main`**.
 
-Any violation blocks merge until corrected.
+Enforcement posture:
+- Report workflow/rubric omissions as **warnings** by default.
+- Escalate to **required fixes (blocking)** only when there is substantive risk to correctness, operability, or long-term architecture.
+
+## Governance Rubric (Required in every PR review)
+### 1) Simplicity Delta
+- Score each PR: `+1` (simplifies), `0` (neutral), `-1` (adds complexity).
+- Any `-1` must include explicit containment and follow-up path.
+
+### 2) Composability Gain
+- Identify reusable primitive/boundary improved.
+- Confirm duplication reduction or future-slice unlock.
+
+### 3) Traceability Coverage
+For all touched decision/action paths, confirm coverage for:
+- `reason` (typed stable enum)
+- `correlation_id` (attempt/request lineage)
+- `event` (typed event name/category)
 
 ## PR Review Output Format (Required)
 For each PR, output:
 - **Decision**: `APPROVE` / `REVISE` / `REJECT`
 - **Architectural impact**: `low` / `med` / `high`
+- **Simplicity Delta**: `+1` / `0` / `-1`
+- **Composability Gain**: `high` / `med` / `low`
+- **Traceability Coverage**: `complete` / `partial` / `missing`
+- **Warnings**: non-blocking gaps
+- **Required fixes**: blocking only for substantive quality/risk
 - **Why**: 2–5 concise bullets
-- **Required follow-ups** (if any)
 
 ## Merge Policy
-Merge to `master` only when all are true:
-1. Workflow compliance is complete.
-2. Architecture decision is `APPROVE`.
-3. Required checks/validation are satisfied.
+Merge to `master` when all are true:
+1. Substantive quality/risk concerns are addressed.
+2. Required checks/validation are satisfied.
+3. Any remaining rubric gaps are documented as warnings + follow-ups.
 
-Default stance: choose pragmatic merges that preserve momentum while containing risk.
+Default stance: preserve momentum; block only on substantive risk.
 
 ---
 
@@ -50,12 +71,12 @@ Default stance: choose pragmatic merges that preserve momentum while containing 
 - [ ] Linked issue exists and is valid (issue-first).
 - [ ] Agent name present in issue and PR.
 - [ ] Work done on proper worktree + branch (not direct on `master`/`main`).
+- [ ] Simplicity Delta scored and justified.
+- [ ] Composability Gain described with concrete reuse impact.
+- [ ] Traceability coverage present for `reason`/`correlation_id`/`event`.
 - [ ] Scope is coherent and appropriately bounded.
-- [ ] Architecture remains simple; complexity added only when justified.
 - [ ] Any "crappy" code is clearly isolated with limited blast radius.
-- [ ] Automagic behavior improves flow without reducing reliability/observability.
 - [ ] Change is observable/tested and rollback path is clear.
-- [ ] Required checks pass (tests/lint/build/CI or documented equivalent).
 - [ ] Review decision recorded in required output format.
 
 ## Balance Strategy: Simplicity, Ecrapsolation, Automagic (6 bullets)


### PR DESCRIPTION
## Summary
Adds repo-level governance scaffolding to enforce the #55 rubric on upcoming PRs while preserving merge velocity.

## Linked issue
Refs #55

## Agent
agent: pr-governor

## What changed
- Added `.github/PULL_REQUEST_TEMPLATE.md` requiring:
  - Simplicity Delta
  - Composability Gain
  - Traceability Coverage (`reason`, `correlation_id`, `event`)
  - warning-vs-blocking policy note
- Updated `docs/agents/PR_GOVERNOR.md` to codify:
  - required rubric fields in review output
  - warnings for non-substantive omissions
  - blocking only for substantive quality/risk

## Why
This creates default-path enforcement for future PRs without over-blocking low-risk changes.

## Validation
- Documentation/template only change
- No runtime code impact
