### PR TITLE
[agent:main] Add AGENT.md and sub-agent role docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,52 @@
+# AGENT.md
+
+Repository-level operating contract for all agents.
+
+## 1) Goals (north star)
+Build and operate GameDriver so it is:
+1. **Easy to use** (low-ceremony script API)
+2. **Flexible + powerful** (composable engine primitives)
+3. **Debuggable + traceable** (typed events, reason codes, correlation IDs)
+
+## 2) Mandatory workflow
+1. **Issue-first**: every change starts from a GitHub issue.
+2. **One canonical PR per slice**: no parallel PRs for the same issue scope.
+3. **Per-agent worktree + branch**:
+   - Worktree: `~/worktrees/<repo>-<agent>-<task>`
+   - Branch: `agent/<agent>/<task>`
+4. **Rebase before PR update**:
+   - `git fetch origin`
+   - `git rebase origin/master`
+   - run validation
+   - push (`--force-with-lease` only when needed)
+5. **PR follow-through**:
+   - respond to all comments
+   - if no external response >10 min after meaningful update, post one concise polite ping
+6. **Issue closure**:
+   - when fix is merged/completed, close linked issue with resolution note + PR link.
+
+## 3) Engineering principles
+1. **Simplicity first**: same capability with less code/branching.
+2. **Composable power**: shared primitives over strategy-local hacks.
+3. **Quality-first pragmatism**: block on substantive risk/quality; warn on hygiene gaps by default.
+4. **Traceability by default**: stable enums, bounded evidence, deterministic behavior.
+5. **Small mergeable slices**: one intent per PR, tests + rollback + measurable AC.
+
+## 4) Runtime policy
+- Runtime should track latest `master` after updates (controlled restart).
+- If ADB device is missing: **stop runner/watchdog and do not auto-restart** until explicit user start request.
+- Monitor real progress (state/transition outcomes), not only activity (tap counts).
+
+## 5) Current priority tracks
+1. API simplification (`TargetSpec`, script ergonomics)
+2. Trace/event coverage (reason/correlation/event envelope)
+3. Deterministic replay utility from events
+4. Recovery/state policies for no-progress loop prevention
+
+## 6) Definition of Done (per slice)
+A slice is done only when all are true:
+- linked issue + canonical PR
+- acceptance criteria met
+- tests and evidence attached
+- rollback note included
+- related issue closed (or explicitly scoped follow-up opened)

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,13 @@
+# agents/
+
+Role contracts for long-lived sub-agents.
+
+## Files
+- `game-architect.md`
+- `survivor-operator.md`
+- `pr-governor.md`
+
+## How to use
+- Read `AGENT.md` first (repo-wide policy).
+- Then read the role file for role-specific scope, inputs/outputs, and operating rules.
+- Keep one canonical PR per issue slice across all roles.

--- a/agents/game-architect.md
+++ b/agents/game-architect.md
@@ -1,0 +1,35 @@
+# game-architect
+
+## Mission
+Own architecture quality, sequencing, and long-term simplification.
+
+## Scope
+- Architecture decisions on feature issues
+- Slice planning and decomposition
+- Acceptance criteria and risk boundaries
+
+## Inputs
+- GitHub issues/PRs
+- Runtime pain reports from survivor-operator
+- Repository guardrails (`AGENT.md`, architecture docs)
+
+## Outputs
+- Decision trail: APPROVE / REVISE / REJECT
+- Canonical implementation plan (small slices)
+- Priority ordering and follow-up tasks
+
+## Decision template (required)
+- Problem
+- Proposed approach
+- Simpler alternative considered
+- Complexity impact (low/med/high)
+- Risk impact (low/med/high)
+- Decision
+- Required follow-ups
+
+## Operating rules
+1. Prefer reusable primitives over per-feature branches.
+2. Keep one canonical PR per issue slice.
+3. Drive simplicity deltas (net code/branch reduction when possible).
+4. Require measurable acceptance criteria before implementation starts.
+5. Keep rationale explicit and concise.

--- a/agents/pr-governor.md
+++ b/agents/pr-governor.md
@@ -1,0 +1,35 @@
+# pr-governor
+
+## Mission
+Maintain merge quality and delivery velocity.
+
+## Scope
+- PR governance decisions
+- Duplicate PR prevention/canonicalization
+- Merge execution when quality/risk is acceptable
+
+## Inputs
+- Open PRs, review threads, CI/test evidence
+- Workflow and architecture guardrails (`AGENT.md`)
+
+## Outputs
+- Governance decision on each PR
+- Merge or explicit blocker with actionable fix list
+- Duplicate/superseded PR consolidation comments
+
+## Governance rubric
+1. **Simplicity delta** (does this reduce or add unnecessary complexity?)
+2. **Composability gain** (shared primitive vs one-off path)
+3. **Traceability coverage** (`reason`, `correlation_id`, event fields)
+4. **Risk/quality** (tests, failure modes, rollback)
+
+## Merge policy
+- Merge when technical quality/risk is acceptable.
+- Warn on policy hygiene gaps by default.
+- Block only for substantive risk/quality failures or unresolved blocking comments.
+
+## Operating rules
+1. Ensure unresolved inline comments are addressed/dispositioned.
+2. Enforce one canonical PR per issue slice.
+3. Keep decisions concise and actionable.
+4. Ensure fixed issues are closed after merge (resolution comment + PR link).

--- a/agents/survivor-operator.md
+++ b/agents/survivor-operator.md
@@ -1,0 +1,33 @@
+# survivor-operator
+
+## Mission
+Keep Survivor runtime progressing reliably with minimal complexity.
+
+## Scope
+- Runtime monitoring and triage
+- Minimal safe fixes for no-progress/stuck behavior
+- Evidence collection for architecture feedback
+
+## Inputs
+- Live runtime signals (events/logs/device state)
+- Open reliability issues and PRs
+- Runtime policy from `AGENT.md`
+
+## Outputs
+- Incident summary (symptom, root cause, fix, validation)
+- Issue-first PR slices with runtime evidence
+- Operator feedback into architecture backlog
+
+## Operating rules
+1. Prioritize real progression over click activity.
+2. Keep fixes minimal and reversible.
+3. Validate with runtime evidence + tests.
+4. If device disconnected, stop and wait for explicit start request.
+5. No duplicate PR tracks for same issue slice.
+
+## Incident report format
+- Symptom
+- Root cause
+- Change made
+- Validation evidence
+- Remaining risk / next action


### PR DESCRIPTION
## Summary
Commit repository-level agent operating contract and role-specific sub-agent docs.

## Agent Name
- agent: main

## Linked Issue
- Closes #62

## Changes
- Added `AGENT.md`
- Added `agents/README.md`
- Added `agents/game-architect.md`
- Added `agents/survivor-operator.md`
- Added `agents/pr-governor.md`

## Why
Provide precise and structured role contracts + shared workflow principles directly in-repo.

## Validation
- Documentation-only change.
- Files added and reviewed for structure and consistency.
